### PR TITLE
fix: Se corrige mismatch de clave en respuesta del perfil

### DIFF
--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -140,7 +140,7 @@ export default function Profile() {
   useEffect(() => {
     getPerfil()
       .then(({ data }) => {
-        const u = data.data.usuario;
+        const u = data.data.user;
         setPerfil(u);
         setEditForm({ nombre: u.nombre ?? '', apellido: u.apellido ?? '', telefono: u.telefono ?? '' });
       })
@@ -177,7 +177,7 @@ export default function Profile() {
         apellido: editForm.apellido.trim(),
         telefono: editForm.telefono.trim() || null,
       });
-      setPerfil(data.data.usuario);
+      setPerfil(data.data.user);
       setEditing(false);
       setEditErrors({});
       setSaved(true);


### PR DESCRIPTION
Profile.jsx leia data.data.usuario pero el backend retorna data.data.user — esto causaba que el perfil apareciera vacio y que los cambios guardados se perdieran en pantalla.

frontend/src/pages/Profile.jsx: data.data.usuario -> data.data.user en carga inicial (useEffect) y en respuesta de updatePerfil