### PR TITLE
feat(auth): login y registro con OAuth de Google y GitHub…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 node_modules/
+Frontend.xlsx
+.env
+.env.local
+.env.*.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "green-alert-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@react-oauth/google": "^0.13.5",
         "axios": "^1.7.2",
         "jspdf": "^4.2.1",
         "jspdf-autotable": "^5.0.7",
@@ -822,6 +823,16 @@
         "leaflet": "^1.9.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.13.5.tgz",
+      "integrity": "sha512-xQWri2s/3nNekZJ4uuov2aAfQYu83bN3864KcFqw2pK1nNbFurQIjPFDXhWaKH3IjYJ2r/9yyIIpsn5lMqrheQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@remix-run/router": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@react-oauth/google": "^0.13.5",
     "axios": "^1.7.2",
     "jspdf": "^4.2.1",
     "jspdf-autotable": "^5.0.7",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ import AdminPanel from './pages/AdminPanel';
 import AdminUsuarios from './pages/AdminUsuarios';
 import PoliticaPrivacidad from './pages/PoliticaPrivacidad';
 import TerminosCondiciones from './pages/TerminosCondiciones';
+import GitHubCallback from './pages/GitHubCallback';
 
 function HomeRoute() {
   const { user } = useAuth();
@@ -53,6 +54,7 @@ export default function App() {
             <Route path="/register"         element={<Auth />} />
             <Route path="/forgot-password"  element={<ForgotPassword />} />
             <Route path="/reset-password"   element={<ResetPassword />} />
+            <Route path="/auth/callback/github" element={<GitHubCallback />} />
 
             {/* ── Rutas protegidas: cualquier usuario autenticado ── */}
             <Route element={<ProtectedRoute />}>

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect } from 'react';
-import { loginUser, registerUser, getPerfil } from '../services/api';
+import { loginUser, registerUser, getPerfil, oauthGoogle, oauthGitHub } from '../services/api';
 import { useToast } from './ToastContext';
 
 const AuthContext = createContext(null);
@@ -52,6 +52,25 @@ export function AuthProvider({ children }) {
     return userData;
   };
 
+  const _saveSession = (token, userData) => {
+    localStorage.setItem('ga_token', token);
+    localStorage.setItem('ga_user', JSON.stringify(userData));
+    setUser(userData);
+    return userData;
+  };
+
+  const loginWithGoogle = async (accessToken) => {
+    const res = await oauthGoogle(accessToken);
+    const { token, user: userData } = res.data.data;
+    return _saveSession(token, userData);
+  };
+
+  const loginWithGitHub = async (code) => {
+    const res = await oauthGitHub(code);
+    const { token, user: userData } = res.data.data;
+    return _saveSession(token, userData);
+  };
+
   const logout = () => {
     localStorage.removeItem('ga_token');
     localStorage.removeItem('ga_user');
@@ -60,7 +79,7 @@ export function AuthProvider({ children }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, loading, login, register, logout, refreshUser }}>
+    <AuthContext.Provider value={{ user, loading, login, register, logout, refreshUser, loginWithGoogle, loginWithGitHub }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { GoogleOAuthProvider } from '@react-oauth/google';
 import App from './App.jsx';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+      <App />
+    </GoogleOAuthProvider>
   </React.StrictMode>
 );

--- a/src/pages/Auth.jsx
+++ b/src/pages/Auth.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { useToast } from '../context/ToastContext';
+import { useGoogleLogin } from '@react-oauth/google';
 import {
   MapPin, Users, BarChart2, Bell,
   CheckCircle2, Lock, Smartphone,
@@ -65,10 +66,52 @@ function Spinner() {
 }
 
 // ── Componente principal ──────────────────────────────────────────────────────
+// ── Botones OAuth reutilizables ──────────────────────────────────────────────
+function OAuthButtons({ oauthLoading, onGoogle, onGitHub, label = 'continúa' }) {
+  return (
+    <div className="mt-5">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="flex-1 h-px bg-gray-800" />
+        <span className="text-xs text-gray-500">o {label} con</span>
+        <div className="flex-1 h-px bg-gray-800" />
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <button
+          type="button"
+          onClick={onGoogle}
+          disabled={!!oauthLoading}
+          className="flex items-center justify-center gap-2 h-10 rounded-xl border border-gray-700 bg-gray-800/60 hover:bg-gray-800 text-gray-300 text-sm font-medium transition disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {oauthLoading === 'google' ? (
+            <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/></svg>
+          ) : (
+            <svg className="w-4 h-4" viewBox="0 0 24 24"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"/><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/></svg>
+          )}
+          Google
+        </button>
+        <button
+          type="button"
+          onClick={onGitHub}
+          disabled={!!oauthLoading}
+          className="flex items-center justify-center gap-2 h-10 rounded-xl border border-gray-700 bg-gray-800/60 hover:bg-gray-800 text-gray-300 text-sm font-medium transition disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {oauthLoading === 'github' ? (
+            <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/></svg>
+          ) : (
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+          )}
+          GitHub
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Componente principal ──────────────────────────────────────────────────────
 export default function Auth() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { login, register } = useAuth();
+  const { login, register, loginWithGoogle, loginWithGitHub } = useAuth();
   const { showToast } = useToast();
 
   // Estado de modo + dirección de la transición
@@ -91,6 +134,35 @@ export default function Auth() {
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname]);
+
+  // ── Estado OAuth ──────────────────────────────────────────────────────────
+  const [oauthLoading, setOauthLoading] = useState('');
+
+  const triggerGoogle = useGoogleLogin({
+    onSuccess: async (tokenResponse) => {
+      setOauthLoading('google');
+      try {
+        const userData = await loginWithGoogle(tokenResponse.access_token);
+        showToast(`¡Bienvenido, ${userData.nombre}!`, 'success', 5000, {
+          position: 'top-center',
+          subtitle: mode === 'login' ? 'Has iniciado sesión con Google' : 'Cuenta creada con Google',
+        });
+        navigate(mode === 'login' ? (location.state?.from || '/dashboard') : '/dashboard', { replace: true });
+      } catch (err) {
+        showToast(err.response?.data?.message || 'Error al continuar con Google.', 'error');
+      } finally {
+        setOauthLoading('');
+      }
+    },
+    onError: () => showToast('Inicio de sesión con Google cancelado.', 'warning'),
+    flow: 'implicit',
+  });
+
+  const handleGitHub = () => {
+    const clientId    = import.meta.env.VITE_GITHUB_CLIENT_ID;
+    const redirectUri = `${window.location.origin}/auth/callback/github`;
+    window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=user:email`;
+  };
 
   // ── Estado del formulario de login ───────────────────────────────────────
   const from = location.state?.from || '/dashboard';
@@ -296,7 +368,14 @@ export default function Auth() {
                     </button>
                   </form>
 
-                  <p className="mt-6 text-center text-sm text-gray-400">
+                  <OAuthButtons
+                    oauthLoading={oauthLoading}
+                    onGoogle={() => triggerGoogle()}
+                    onGitHub={handleGitHub}
+                    label="continúa"
+                  />
+
+                  <p className="mt-5 text-center text-sm text-gray-400">
                     ¿No tienes cuenta?{' '}
                     <button
                       onClick={() => switchTo('register')}
@@ -416,6 +495,13 @@ export default function Auth() {
                       }
                     </button>
                   </form>
+
+                  <OAuthButtons
+                    oauthLoading={oauthLoading}
+                    onGoogle={() => triggerGoogle()}
+                    onGitHub={handleGitHub}
+                    label="regístrate"
+                  />
 
                   <p className="mt-5 text-center text-sm text-gray-400">
                     ¿Ya tienes cuenta?{' '}

--- a/src/pages/GitHubCallback.jsx
+++ b/src/pages/GitHubCallback.jsx
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { useToast } from '../context/ToastContext';
+import { motion } from 'motion/react';
+
+export default function GitHubCallback() {
+  const [searchParams] = useSearchParams();
+  const { loginWithGitHub } = useAuth();
+  const { showToast } = useToast();
+  const navigate = useNavigate();
+  const called = useRef(false);
+
+  useEffect(() => {
+    if (called.current) return;
+    called.current = true;
+
+    const code  = searchParams.get('code');
+    const error = searchParams.get('error');
+
+    if (error || !code) {
+      showToast('Inicio de sesión con GitHub cancelado.', 'warning');
+      navigate('/login', { replace: true });
+      return;
+    }
+
+    loginWithGitHub(code)
+      .then((userData) => {
+        showToast(`¡Bienvenido, ${userData.nombre}!`, 'success', 5000, {
+          position: 'top-center',
+          subtitle: 'Has iniciado sesión con GitHub',
+        });
+        navigate('/dashboard', { replace: true });
+      })
+      .catch((err) => {
+        showToast(err.response?.data?.message || 'Error al iniciar sesión con GitHub.', 'error');
+        navigate('/login', { replace: true });
+      });
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gray-950 flex items-center justify-center">
+      <motion.div
+        className="flex flex-col items-center gap-4 text-gray-400"
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+      >
+        <svg className="w-8 h-8 animate-spin text-green-400" fill="none" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+        </svg>
+        <p className="text-sm">Completando inicio de sesión con GitHub...</p>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../context/AuthContext';
 import { useToast } from '../context/ToastContext';
 import { MapPin, Users, BarChart2, Bell, Eye, EyeOff } from 'lucide-react';
 import { motion } from 'motion/react';
+import { useGoogleLogin } from '@react-oauth/google';
 import NebulaBackground from '../components/NebulaBackground';
 
 const features = [
@@ -28,7 +29,7 @@ const fieldVariants = {
 };
 
 export default function Login() {
-  const { login } = useAuth();
+  const { login, loginWithGoogle } = useAuth();
   const { showToast } = useToast();
   const navigate = useNavigate();
   const location = useLocation();
@@ -36,9 +37,36 @@ export default function Login() {
 
   const [form, setForm] = useState({ email: '', password: '' });
   const [loading, setLoading] = useState(false);
+  const [oauthLoading, setOauthLoading] = useState('');
   const [showPassword, setShowPassword] = useState(false);
 
   const set = (k, v) => setForm((f) => ({ ...f, [k]: v }));
+
+  const handleGoogleSuccess = useGoogleLogin({
+    onSuccess: async (tokenResponse) => {
+      setOauthLoading('google');
+      try {
+        const userData = await loginWithGoogle(tokenResponse.access_token);
+        showToast(`¡Bienvenido, ${userData.nombre}!`, 'success', 5000, {
+          position: 'top-center', subtitle: 'Has iniciado sesión con Google',
+        });
+        navigate(from, { replace: true });
+      } catch (err) {
+        showToast(err.response?.data?.message || 'Error al iniciar sesión con Google.', 'error');
+      } finally {
+        setOauthLoading('');
+      }
+    },
+    onError: () => showToast('Inicio de sesión con Google cancelado.', 'warning'),
+    flow: 'implicit',
+  });
+
+  const handleGitHub = () => {
+    const clientId    = import.meta.env.VITE_GITHUB_CLIENT_ID;
+    const redirectUri = `${window.location.origin}/auth/callback/github`;
+    const scope       = 'user:email';
+    window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=${scope}`;
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -203,8 +231,43 @@ export default function Login() {
               </motion.div>
             </form>
 
+            {/* ── OAuth ── */}
+            <motion.div custom={4} variants={fieldVariants} initial="hidden" animate="show" className="mt-5">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="flex-1 h-px bg-gray-800" />
+                <span className="text-xs text-gray-500">o continúa con</span>
+                <div className="flex-1 h-px bg-gray-800" />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                {/* Google */}
+                <button
+                  type="button"
+                  onClick={() => handleGoogleSuccess()}
+                  disabled={!!oauthLoading}
+                  className="flex items-center justify-center gap-2 h-10 rounded-xl border border-gray-700 bg-gray-800/60 hover:bg-gray-800 text-gray-300 text-sm font-medium transition disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {oauthLoading === 'google' ? (
+                    <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/></svg>
+                  ) : (
+                    <svg className="w-4 h-4" viewBox="0 0 24 24"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"/><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/></svg>
+                  )}
+                  Google
+                </button>
+                {/* GitHub */}
+                <button
+                  type="button"
+                  onClick={handleGitHub}
+                  disabled={!!oauthLoading}
+                  className="flex items-center justify-center gap-2 h-10 rounded-xl border border-gray-700 bg-gray-800/60 hover:bg-gray-800 text-gray-300 text-sm font-medium transition disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+                  GitHub
+                </button>
+              </div>
+            </motion.div>
+
             <motion.p
-              custom={4}
+              custom={5}
               variants={fieldVariants}
               initial="hidden"
               animate="show"

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../context/AuthContext';
 import { useToast } from '../context/ToastContext';
 import { CheckCircle2, Lock, Smartphone, Eye, EyeOff } from 'lucide-react';
 import { motion } from 'motion/react';
+import { useGoogleLogin } from '@react-oauth/google';
 import PasswordStrengthIndicator from '../components/PasswordStrengthIndicator';
 import NebulaBackground from '../components/NebulaBackground';
 
@@ -21,7 +22,7 @@ const fieldVariants = {
 };
 
 export default function Register() {
-  const { register } = useAuth();
+  const { register, loginWithGoogle } = useAuth();
   const { showToast } = useToast();
   const navigate = useNavigate();
 
@@ -30,10 +31,36 @@ export default function Register() {
     password: '', confirmar: '',
   });
   const [loading, setLoading] = useState(false);
+  const [oauthLoading, setOauthLoading] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [passwordFocused, setPasswordFocused] = useState(false);
 
   const set = (k, v) => setForm((f) => ({ ...f, [k]: v }));
+
+  const handleGoogleSuccess = useGoogleLogin({
+    onSuccess: async (tokenResponse) => {
+      setOauthLoading('google');
+      try {
+        const userData = await loginWithGoogle(tokenResponse.access_token);
+        showToast(`¡Bienvenido, ${userData.nombre}!`, 'success', 5000, {
+          position: 'top-center', subtitle: 'Cuenta creada con Google',
+        });
+        navigate('/dashboard', { replace: true });
+      } catch (err) {
+        showToast(err.response?.data?.message || 'Error al registrarse con Google.', 'error');
+      } finally {
+        setOauthLoading('');
+      }
+    },
+    onError: () => showToast('Registro con Google cancelado.', 'warning'),
+    flow: 'implicit',
+  });
+
+  const handleGitHub = () => {
+    const clientId    = import.meta.env.VITE_GITHUB_CLIENT_ID;
+    const redirectUri = `${window.location.origin}/auth/callback/github`;
+    window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=user:email`;
+  };
 
   const validate = () => {
     if (form.nombre.trim().length < 2)          return 'El nombre debe tener al menos 2 caracteres.';
@@ -231,7 +258,40 @@ export default function Register() {
               </motion.div>
             </form>
 
-            <motion.p custom={6} variants={fieldVariants} initial="hidden" animate="show"
+            {/* ── OAuth ── */}
+            <motion.div custom={6} variants={fieldVariants} initial="hidden" animate="show" className="mt-4">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="flex-1 h-px bg-gray-800" />
+                <span className="text-xs text-gray-500">o regístrate con</span>
+                <div className="flex-1 h-px bg-gray-800" />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <button
+                  type="button"
+                  onClick={() => handleGoogleSuccess()}
+                  disabled={!!oauthLoading}
+                  className="flex items-center justify-center gap-2 h-10 rounded-xl border border-gray-700 bg-gray-800/60 hover:bg-gray-800 text-gray-300 text-sm font-medium transition disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {oauthLoading === 'google' ? (
+                    <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/></svg>
+                  ) : (
+                    <svg className="w-4 h-4" viewBox="0 0 24 24"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"/><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/></svg>
+                  )}
+                  Google
+                </button>
+                <button
+                  type="button"
+                  onClick={handleGitHub}
+                  disabled={!!oauthLoading}
+                  className="flex items-center justify-center gap-2 h-10 rounded-xl border border-gray-700 bg-gray-800/60 hover:bg-gray-800 text-gray-300 text-sm font-medium transition disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+                  GitHub
+                </button>
+              </div>
+            </motion.div>
+
+            <motion.p custom={7} variants={fieldVariants} initial="hidden" animate="show"
               className="mt-5 text-center text-sm text-gray-400">
               ¿Ya tienes cuenta?{' '}
               <Link to="/login" className="text-green-400 hover:text-green-300 font-medium transition-colors">

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -31,6 +31,8 @@ export const checkHealth = () => api.get('/health');
 // ── Auth ──
 export const loginUser    = (email, password)                                   => api.post('/auth/login',    { email, password });
 export const registerUser = (nombre, apellido, email, password, telefono)       => api.post('/auth/register', { nombre, apellido, email, password, telefono });
+export const oauthGoogle  = (access_token)                                      => api.post('/auth/google',   { access_token });
+export const oauthGitHub  = (code)                                              => api.post('/auth/github',   { code });
 
 // ── Categorías ──
 export const getCategorias         = ()       => api.get('/categorias');


### PR DESCRIPTION
## Descripción
Se implemento el inicio de sesion tanto con cuentas Google y Github en los paartados de Inicio de Sesion y el formulario de registro.

### Implementación realizada:

- Agregar botones OAuth de Google y GitHub en Login, Register y Auth
- Agregar página GitHubCallback para manejar el redirect de GitHub
- Actualizar AuthContext para soportar sesión OAuth
- Registrar rutas OAuth en App.jsx
- Añadir dependencias OAuth en package.json
- Actualizar .gitignore y api.js para endpoints OAuth

## Inicio de Sesion
<img width="667" height="633" alt="image" src="https://github.com/user-attachments/assets/5ebf9ff3-a054-4790-b7a9-e620b058af2b" />

## Formulario de Registro
<img width="661" height="636" alt="image" src="https://github.com/user-attachments/assets/2090e93f-436f-4309-83ed-edc034329fd6" />

