### PR TITLE
feat(auth): agregar OAuth con Facebook y eliminar GitHub 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,7 @@ import AdminPanel from './pages/AdminPanel';
 import AdminUsuarios from './pages/AdminUsuarios';
 import PoliticaPrivacidad from './pages/PoliticaPrivacidad';
 import TerminosCondiciones from './pages/TerminosCondiciones';
-import GitHubCallback from './pages/GitHubCallback';
+import FacebookCallback from './pages/FacebookCallback';
 
 function HomeRoute() {
   const { user } = useAuth();
@@ -54,7 +54,7 @@ export default function App() {
             <Route path="/register"         element={<Auth />} />
             <Route path="/forgot-password"  element={<ForgotPassword />} />
             <Route path="/reset-password"   element={<ResetPassword />} />
-            <Route path="/auth/callback/github" element={<GitHubCallback />} />
+            <Route path="/auth/callback/facebook"  element={<FacebookCallback />} />
 
             {/* ── Rutas protegidas: cualquier usuario autenticado ── */}
             <Route element={<ProtectedRoute />}>

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useEffect } from 'react';
-import { loginUser, registerUser, getPerfil, oauthGoogle, oauthGitHub } from '../services/api';
+import { loginUser, registerUser, getPerfil, oauthGoogle, oauthFacebook } from '../services/api';
 import { useToast } from './ToastContext';
 
 const AuthContext = createContext(null);
@@ -65,8 +65,8 @@ export function AuthProvider({ children }) {
     return _saveSession(token, userData);
   };
 
-  const loginWithGitHub = async (code) => {
-    const res = await oauthGitHub(code);
+  const loginWithFacebook = async (code) => {
+    const res = await oauthFacebook(code);
     const { token, user: userData } = res.data.data;
     return _saveSession(token, userData);
   };
@@ -79,7 +79,7 @@ export function AuthProvider({ children }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, loading, login, register, logout, refreshUser, loginWithGoogle, loginWithGitHub }}>
+    <AuthContext.Provider value={{ user, loading, login, register, logout, refreshUser, loginWithGoogle, loginWithFacebook }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/pages/Auth.jsx
+++ b/src/pages/Auth.jsx
@@ -67,7 +67,7 @@ function Spinner() {
 
 // ── Componente principal ──────────────────────────────────────────────────────
 // ── Botones OAuth reutilizables ──────────────────────────────────────────────
-function OAuthButtons({ oauthLoading, onGoogle, onGitHub, label = 'continúa' }) {
+function OAuthButtons({ oauthLoading, onGoogle, onFacebook, label = 'continúa' }) {
   return (
     <div className="mt-5">
       <div className="flex items-center gap-3 mb-4">
@@ -91,16 +91,16 @@ function OAuthButtons({ oauthLoading, onGoogle, onGitHub, label = 'continúa' })
         </button>
         <button
           type="button"
-          onClick={onGitHub}
+          onClick={onFacebook}
           disabled={!!oauthLoading}
           className="flex items-center justify-center gap-2 h-10 rounded-xl border border-gray-700 bg-gray-800/60 hover:bg-gray-800 text-gray-300 text-sm font-medium transition disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {oauthLoading === 'github' ? (
+          {oauthLoading === 'facebook' ? (
             <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"/><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/></svg>
           ) : (
-            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="#1877F2"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
           )}
-          GitHub
+          Facebook
         </button>
       </div>
     </div>
@@ -111,7 +111,7 @@ function OAuthButtons({ oauthLoading, onGoogle, onGitHub, label = 'continúa' })
 export default function Auth() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { login, register, loginWithGoogle, loginWithGitHub } = useAuth();
+  const { login, register, loginWithGoogle, loginWithFacebook } = useAuth();
   const { showToast } = useToast();
 
   // Estado de modo + dirección de la transición
@@ -158,10 +158,13 @@ export default function Auth() {
     flow: 'implicit',
   });
 
-  const handleGitHub = () => {
-    const clientId    = import.meta.env.VITE_GITHUB_CLIENT_ID;
-    const redirectUri = `${window.location.origin}/auth/callback/github`;
-    window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=user:email`;
+  const handleFacebook = () => {
+    const url = new URL('https://www.facebook.com/v19.0/dialog/oauth');
+    url.searchParams.set('client_id',     import.meta.env.VITE_FACEBOOK_APP_ID);
+    url.searchParams.set('redirect_uri',  `${window.location.origin}/auth/callback/facebook`);
+    url.searchParams.set('scope',         'email,public_profile');
+    url.searchParams.set('response_type', 'code');
+    window.location.href = url.toString();
   };
 
   // ── Estado del formulario de login ───────────────────────────────────────
@@ -371,7 +374,7 @@ export default function Auth() {
                   <OAuthButtons
                     oauthLoading={oauthLoading}
                     onGoogle={() => triggerGoogle()}
-                    onGitHub={handleGitHub}
+                    onFacebook={handleFacebook}
                     label="continúa"
                   />
 
@@ -499,7 +502,7 @@ export default function Auth() {
                   <OAuthButtons
                     oauthLoading={oauthLoading}
                     onGoogle={() => triggerGoogle()}
-                    onGitHub={handleGitHub}
+                    onFacebook={handleFacebook}
                     label="regístrate"
                   />
 

--- a/src/pages/FacebookCallback.jsx
+++ b/src/pages/FacebookCallback.jsx
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { useToast } from '../context/ToastContext';
+import { motion } from 'motion/react';
+
+export default function FacebookCallback() {
+  const [searchParams] = useSearchParams();
+  const { loginWithFacebook } = useAuth();
+  const { showToast } = useToast();
+  const navigate = useNavigate();
+  const called = useRef(false);
+
+  useEffect(() => {
+    if (called.current) return;
+    called.current = true;
+
+    const code  = searchParams.get('code');
+    const error = searchParams.get('error');
+
+    if (error || !code) {
+      showToast('Inicio de sesión con Facebook cancelado.', 'warning');
+      navigate('/login', { replace: true });
+      return;
+    }
+
+    loginWithFacebook(code)
+      .then((userData) => {
+        showToast(`¡Bienvenido, ${userData.nombre}!`, 'success', 5000, {
+          position: 'top-center',
+          subtitle: 'Has iniciado sesión con Facebook',
+        });
+        navigate('/dashboard', { replace: true });
+      })
+      .catch((err) => {
+        showToast(err.response?.data?.message || 'Error al iniciar sesión con Facebook.', 'error');
+        navigate('/login', { replace: true });
+      });
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gray-950 flex items-center justify-center">
+      <motion.div
+        className="flex flex-col items-center gap-4 text-gray-400"
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+      >
+        <svg className="w-8 h-8 animate-spin text-blue-400" fill="none" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+        </svg>
+        <p className="text-sm">Completando inicio de sesión con Facebook...</p>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -31,8 +31,8 @@ export const checkHealth = () => api.get('/health');
 // ── Auth ──
 export const loginUser    = (email, password)                                   => api.post('/auth/login',    { email, password });
 export const registerUser = (nombre, apellido, email, password, telefono)       => api.post('/auth/register', { nombre, apellido, email, password, telefono });
-export const oauthGoogle  = (access_token)                                      => api.post('/auth/google',   { access_token });
-export const oauthGitHub  = (code)                                              => api.post('/auth/github',   { code });
+export const oauthGoogle   = (access_token) => api.post('/auth/google',   { access_token });
+export const oauthFacebook = (code)          => api.post('/auth/facebook', { code });
 
 // ── Categorías ──
 export const getCategorias         = ()       => api.get('/categorias');


### PR DESCRIPTION
- Reemplazar flujo OAuth de GitHub por Facebook en Auth, AuthContext y api.js
- Agregar página FacebookCallback para manejar redirect de Facebook
- Actualizar rutas en App.jsx

### Inicio de Sesion
<img width="679" height="636" alt="{4C7B45CB-19F7-4975-923A-3E2D623A84E7}" src="https://github.com/user-attachments/assets/32f5152c-f863-4fc4-a6ac-f29717971a59" />

### Formulario de Registro
<img width="672" height="633" alt="{4D57D88F-3781-4EC7-806C-8A03C9D1E769}" src="https://github.com/user-attachments/assets/3fd073f6-250c-43f0-b697-9f47dcf1741b" />
