### PR TITLE
fix(mapas): establecer CARTO Voyager como estilo de mapa predeterminado

### DIFF
--- a/src/components/LocationPicker.jsx
+++ b/src/components/LocationPicker.jsx
@@ -4,6 +4,27 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { reverseGeocode } from '../utils/geo';
 
+const MAP_TILES = [
+  {
+    key: 'light',
+    label: 'Claro',
+    url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+  },
+  {
+    key: 'dark',
+    label: 'Oscuro',
+    url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+  },
+  {
+    key: 'satellite',
+    label: 'Satélite',
+    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+    attribution: '&copy; <a href="https://www.esri.com/">Esri</a>, Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP',
+  },
+];
+
 const pickerIcon = L.divIcon({
   className: '',
   html: `<div style="
@@ -45,6 +66,13 @@ export default function LocationPicker({ latitud, longitud, onChange, initialCen
     return !isNaN(lat) && !isNaN(lng) ? { lat, lng } : null;
   });
   const [geocoding, setGeocoding] = useState(false);
+  const [mapStyle, setMapStyle] = useState(() => localStorage.getItem('ga-map-style') || 'light');
+  const tile = MAP_TILES.find((t) => t.key === mapStyle) ?? MAP_TILES[0];
+
+  const handleStyleChange = (key) => {
+    setMapStyle(key);
+    localStorage.setItem('ga-map-style', key);
+  };
 
   const handlePick = useCallback(
     async (latlng) => {
@@ -66,20 +94,41 @@ export default function LocationPicker({ latitud, longitud, onChange, initialCen
           ? `Seleccionado: ${position.lat.toFixed(5)}, ${position.lng.toFixed(5)}`
           : 'Haz clic en el mapa para fijar la ubicación exacta'}
       </p>
-      <div className="h-56 sm:h-80 lg:h-[420px]" style={{ borderRadius: '0.75rem', overflow: 'hidden' }}>
-        <MapContainer
-          center={initialCenter ?? [4.5709, -74.2973]}
-          zoom={initialCenter ? 14 : 6}
-          style={{ height: '100%', width: '100%' }}
-        >
-          <TileLayer
-            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-          />
-          <ClickHandler onPick={handlePick} />
-          <FlyToCenter center={initialCenter} />
-          {position && <Marker position={position} icon={pickerIcon} />}
-        </MapContainer>
+      <div className="relative">
+        {/* Selector de estilo de mapa */}
+        <div className="absolute top-2 right-2 z-[1000] flex gap-0.5 bg-gray-950/90 backdrop-blur border border-gray-700 rounded-lg p-0.5">
+          {MAP_TILES.map((t) => (
+            <button
+              key={t.key}
+              onClick={() => handleStyleChange(t.key)}
+              title={t.label}
+              type="button"
+              className={`px-2 py-1 rounded-md text-[11px] font-medium transition-colors ${
+                mapStyle === t.key
+                  ? 'bg-gray-700 text-white'
+                  : 'text-gray-400 hover:text-gray-200'
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        <div className="h-56 sm:h-80 lg:h-[420px]" style={{ borderRadius: '0.75rem', overflow: 'hidden', isolation: 'isolate' }}>
+          <MapContainer
+            center={initialCenter ?? [4.5709, -74.2973]}
+            zoom={initialCenter ? 14 : 6}
+            style={{ height: '100%', width: '100%' }}
+            className={`ga-map-${mapStyle}`}
+          >
+            <TileLayer
+              url={tile.url}
+              attribution={tile.attribution}
+            />
+            <ClickHandler onPick={handlePick} />
+            <FlyToCenter center={initialCenter} />
+            {position && <Marker position={position} icon={pickerIcon} />}
+          </MapContainer>
+        </div>
       </div>
     </div>
   );

--- a/src/components/ReportsMap.jsx
+++ b/src/components/ReportsMap.jsx
@@ -1,10 +1,31 @@
-﻿import { memo, useEffect, useRef } from 'react';
+﻿import { memo, useEffect, useRef, useState } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, useMap, CircleMarker } from 'react-leaflet';
 import MarkerClusterGroup from 'react-leaflet-cluster';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { useNavigate } from 'react-router-dom';
 import { helpers } from '../constants/categorias';
+
+const MAP_TILES = [
+  {
+    key: 'light',
+    label: 'Claro',
+    url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+  },
+  {
+    key: 'dark',
+    label: 'Oscuro',
+    url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+  },
+  {
+    key: 'satellite',
+    label: 'Satélite',
+    url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+    attribution: '&copy; <a href="https://www.esri.com/">Esri</a>, Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP',
+  },
+];
 
 const createIcon = (color) =>
   L.divIcon({
@@ -229,6 +250,13 @@ function PrediccionLayer({ zonas = [] }) {
 export default memo(function ReportsMap({ reports = [], mode = 'cluster', zonas = [] }) {
   const navigate = useNavigate();
   const withCoords = reports.filter((r) => r.latitud && r.longitud);
+  const [mapStyle, setMapStyle] = useState(() => localStorage.getItem('ga-map-style') || 'light');
+  const tile = MAP_TILES.find((t) => t.key === mapStyle) ?? MAP_TILES[0];
+
+  const handleStyleChange = (key) => {
+    setMapStyle(key);
+    localStorage.setItem('ga-map-style', key);
+  };
 
   // En modo predicción usamos el conjunto de zonas; el mapa se muestra
   // aunque no haya `reports` (la capa predictiva proviene de su propio fetch).
@@ -246,16 +274,34 @@ export default memo(function ReportsMap({ reports = [], mode = 'cluster', zonas 
   }
 
   return (
-    <MapContainer
-      center={[4.5709, -74.2973]}
-      zoom={6}
-      style={{ height: '100%', width: '100%' }}
-      className="z-0 ga-map"
-    >
+    <div className="relative h-full w-full" style={{ isolation: 'isolate' }}>
+      {/* Selector de estilo de mapa */}
+      <div className="absolute top-2 right-2 z-[1000] flex gap-0.5 bg-gray-950/90 backdrop-blur border border-gray-700 rounded-lg p-0.5">
+        {MAP_TILES.map((t) => (
+          <button
+            key={t.key}
+            onClick={() => handleStyleChange(t.key)}
+            title={t.label}
+            className={`px-2 py-1 rounded-md text-[11px] font-medium transition-colors ${
+              mapStyle === t.key
+                ? 'bg-gray-700 text-white'
+                : 'text-gray-400 hover:text-gray-200'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+      <MapContainer
+        center={[4.5709, -74.2973]}
+        zoom={6}
+        style={{ height: '100%', width: '100%' }}
+        className={`z-0 ga-map-${mapStyle}`}
+      >
       <TileLayer
-        url="https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
-        maxZoom={19}
+          url={tile.url}
+          attribution={tile.attribution}
+          maxZoom={19}
       />
       {isPrediccion ? (
         <>
@@ -349,5 +395,6 @@ export default memo(function ReportsMap({ reports = [], mode = 'cluster', zonas 
         </>
       )}
     </MapContainer>
+    </div>
   );
 });


### PR DESCRIPTION
## Descripción

Los mapas cargaban en modo oscuro por defecto. Se reordena MAP_TILES para que 'light' quede en indice 0 en ambos componentes. El fallback de localStorage cambia a 'light', garantizando modo claro cuando no hay preferencia guardada.

### Archivos afectados:
- src/components/ReportsMap.jsx — 'light' movido al indice 0 de MAP_TILES, default localStorage a 'light'
- src/components/LocationPicker.jsx — misma correccion del array de tiles y localStorage

Closes #85

<img width="877" height="623" alt="image" src="https://github.com/user-attachments/assets/991f0f93-6a7c-48f6-8dcd-be06cdc089ea" />

---

<img width="864" height="607" alt="image" src="https://github.com/user-attachments/assets/58e2a38c-faab-463c-89a7-9bd9e0d94552" />

