### PR TITLE
fix(mapas): corregir z-index de Leaflet sobre Navbar y chatbot

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -22,10 +22,19 @@
   .badge {
     @apply inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium;
   }
-  /* Mapa — ajusta las tiles al tono charcoal de la paleta gray-900 del proyecto */
-  .ga-map .leaflet-tile-pane {
+  /* Mapa — filtros por estilo de tile */
+  /* isolation: isolate crea un stacking context propio para Leaflet,
+     evitando que sus z-indices (400, 1000) se filtren al documento global */
+  .leaflet-container {
+    isolation: isolate;
+  }
+  .ga-map-dark .leaflet-tile-pane {
     filter: brightness(1.35) saturate(0.75);
   }
+  .ga-map-satellite .leaflet-tile-pane {
+    filter: brightness(1.05) contrast(1.05) saturate(1.1);
+  }
+  /* .ga-map-light (Voyager): sin filtro, los colores son correctos por defecto */
 
   .scrollbar-dark {
     scrollbar-width: thin;


### PR DESCRIPTION
## Descripción
Los controles y tiles de Leaflet escapaban del stacking context y aparecian sobre el Navbar y el widget del chatbot. Se aplica isolation: isolate en todos los wrappers de mapas para crear un contexto de apilamiento contenido.

### Archivos afectados:
- src/index.css - regla global .leaflet-container { isolation: isolate } para instancias futuras
- src/pages/ReportDetail.jsx - isolation: isolate en el wrapper de ReportDetailMap Nota: ReportsMap.jsx y LocationPicker.jsx incluidos en fix/85 (#85)

Closes #87

<img width="888" height="73" alt="image" src="https://github.com/user-attachments/assets/9f9e05df-2b51-49ab-a8d3-9401252949a2" />
