### PR TITLE
feat(admin): redisenar panel de administración

### DIFF
--- a/src/pages/AdminPanel.jsx
+++ b/src/pages/AdminPanel.jsx
@@ -3,17 +3,11 @@ import { Link } from 'react-router-dom';
 import {
   Shield, Users, FileText, ShieldCheck,
   TrendingUp, AlertTriangle, CheckCircle2, Clock,
-  ArrowRight, Loader2,
+  ArrowRight, Loader2, UserCheck, UserX, UserPlus, Activity,
 } from 'lucide-react';
 import { motion } from 'motion/react';
 import { getAdminStats } from '../services/api';
 import { CountUp } from '../utils/animations.jsx';
-
-const rolColor = {
-  ciudadano: 'text-green-400',
-  moderador:  'text-blue-400',
-  admin:      'text-yellow-400',
-};
 
 export default function AdminPanel() {
   const [stats,   setStats]   = useState(null);
@@ -28,17 +22,27 @@ export default function AdminPanel() {
   }, []);
 
   return (
-    <div className="max-w-5xl mx-auto px-4 sm:px-6 py-10 space-y-10">
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 py-8 space-y-8">
 
       {/* Encabezado */}
-      <div className="flex items-start gap-4">
-        <div className="w-12 h-12 rounded-2xl bg-yellow-500/10 border border-yellow-500/25 flex items-center justify-center shrink-0">
-          <Shield className="w-6 h-6 text-yellow-400" />
+      <div className="flex items-start sm:items-center justify-between flex-wrap gap-4">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-xl bg-yellow-500/10 border border-yellow-500/25 flex items-center justify-center shrink-0">
+            <Shield className="w-5 h-5 text-yellow-400" />
+          </div>
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-white">
+              Panel de <span className="text-yellow-400">Administración</span>
+            </h1>
+            <p className="text-sm text-gray-500">Vista general del sistema GreenAlert</p>
+          </div>
         </div>
-        <div>
-          <h1 className="text-2xl sm:text-3xl font-bold text-white">Panel de Administración</h1>
-          <p className="text-sm text-gray-400 mt-0.5">Vista general del sistema GreenAlert</p>
-        </div>
+        {!loading && !error && (
+          <div className="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full bg-green-500/10 border border-green-500/20 text-green-400 text-xs font-medium">
+            <span className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
+            Sistema en línea
+          </div>
+        )}
       </div>
 
       {error && (
@@ -53,83 +57,114 @@ export default function AdminPanel() {
         </div>
       ) : stats && (
         <>
-          {/* Stats de usuarios */}
+          {/* ── Usuarios ── */}
           <section className="space-y-3">
-            <div className="flex items-center gap-2.5">
-              <span className="block w-1 h-5 rounded-full bg-green-400" />
-              <h2 className="text-xs font-bold text-gray-300 uppercase tracking-widest">Usuarios</h2>
+            <div className="flex items-center gap-3">
+              <div className="w-6 h-6 rounded-md bg-green-500/10 border border-green-500/20 flex items-center justify-center shrink-0">
+                <Users size={13} className="text-green-400" />
+              </div>
+              <h2 className="text-sm font-semibold text-gray-300">Usuarios</h2>
+              <div className="flex-1 h-px bg-gray-800" />
             </div>
+
+            {/* Tarjetas principales de roles */}
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
               {[
-                { label: 'Total',       value: stats.usuarios?.total,       icon: Users,       color: 'text-gray-200',   accent: '#6B7280', ibg: 'bg-gray-500/10' },
-                { label: 'Ciudadanos',  value: stats.usuarios?.ciudadanos,  icon: Users,       color: 'text-green-400',  accent: '#22C55E', ibg: 'bg-green-500/10' },
-                { label: 'Moderadores', value: stats.usuarios?.moderadores, icon: ShieldCheck, color: 'text-blue-400',   accent: '#3B82F6', ibg: 'bg-blue-500/10' },
-                { label: 'Admins',      value: stats.usuarios?.admins,      icon: Shield,      color: 'text-yellow-400', accent: '#EAB308', ibg: 'bg-yellow-500/10' },
-              ].map(({ label, value, icon: Icon, color, accent, ibg }, i) => (
+                { label: 'Total',       value: stats.usuarios?.total,       icon: Users,       accent: '#9CA3AF', ibg: 'bg-gray-500/10',   border: 'border-gray-600/30' },
+                { label: 'Ciudadanos',  value: stats.usuarios?.ciudadanos,  icon: Users,       accent: '#22C55E', ibg: 'bg-green-500/10',  border: 'border-green-500/20' },
+                { label: 'Moderadores', value: stats.usuarios?.moderadores, icon: ShieldCheck, accent: '#3B82F6', ibg: 'bg-blue-500/10',   border: 'border-blue-500/20' },
+                { label: 'Admins',      value: stats.usuarios?.admins,      icon: Shield,      accent: '#EAB308', ibg: 'bg-yellow-500/10', border: 'border-yellow-500/20' },
+              ].map(({ label, value, icon: Icon, accent, ibg, border }, i) => (
                 <motion.div
                   key={label}
-                  initial={{ opacity: 0, y: 10 }}
+                  initial={{ opacity: 0, y: 12 }}
                   animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: i * 0.06 }}
-                  className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden"
-                  style={{ borderTop: `2px solid ${accent}` }}
+                  transition={{ delay: i * 0.07 }}
+                  className="relative bg-gray-900 border border-gray-800 rounded-xl overflow-hidden group hover:border-gray-700 transition-colors"
                 >
-                  <div className="p-4 flex flex-col gap-3">
-                    <div className={`w-8 h-8 rounded-lg ${ibg} flex items-center justify-center`}>
-                      <Icon size={15} className={color} />
+                  <div
+                    className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none"
+                    style={{ background: `radial-gradient(ellipse at top right, ${accent}10 0%, transparent 65%)` }}
+                  />
+                  <div className="relative p-4 flex flex-col gap-3">
+                    <div className={`w-9 h-9 rounded-lg ${ibg} border ${border} flex items-center justify-center`}>
+                      <Icon size={16} style={{ color: accent }} />
                     </div>
                     <div>
-                      <p className={`text-2xl font-bold ${color}`}><CountUp target={value ?? 0} /></p>
+                      <p className="text-2xl font-bold" style={{ color: accent }}>
+                        <CountUp target={value ?? 0} />
+                      </p>
                       <p className="text-xs text-gray-500 mt-0.5">{label}</p>
                     </div>
                   </div>
                 </motion.div>
               ))}
             </div>
+
+            {/* Fila secundaria */}
             <div className="grid grid-cols-3 gap-3">
               {[
-                { label: 'Activos',         value: stats.usuarios?.activos,         color: 'text-green-400', dot: 'bg-green-400' },
-                { label: 'Inactivos',       value: stats.usuarios?.inactivos,       color: 'text-red-400',   dot: 'bg-red-400' },
-                { label: 'Nuevos este mes', value: stats.usuarios?.nuevos_este_mes, color: 'text-sky-400',   dot: 'bg-sky-400' },
-              ].map(({ label, value, color, dot }) => (
-                <div key={label} className="bg-gray-900 border border-gray-800 rounded-xl p-4 flex items-center gap-3">
-                  <span className={`w-2 h-2 rounded-full shrink-0 ${dot}`} />
+                { label: 'Activos',         value: stats.usuarios?.activos,         icon: UserCheck, accent: '#22C55E', ibg: 'bg-green-500/8'  },
+                { label: 'Inactivos',       value: stats.usuarios?.inactivos,       icon: UserX,     accent: '#EF4444', ibg: 'bg-red-500/8'    },
+                { label: 'Nuevos este mes', value: stats.usuarios?.nuevos_este_mes, icon: UserPlus,  accent: '#38BDF8', ibg: 'bg-sky-500/8'    },
+              ].map(({ label, value, icon: Icon, accent, ibg }, i) => (
+                <motion.div
+                  key={label}
+                  initial={{ opacity: 0, y: 12 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.28 + i * 0.07 }}
+                  className="bg-gray-900 border border-gray-800 rounded-xl p-4 flex items-center gap-3 hover:border-gray-700 transition-colors"
+                >
+                  <div className={`w-8 h-8 rounded-lg ${ibg} flex items-center justify-center shrink-0`}>
+                    <Icon size={15} style={{ color: accent }} />
+                  </div>
                   <div>
-                    <p className={`text-xl font-bold ${color}`}><CountUp target={value ?? 0} /></p>
+                    <p className="text-xl font-bold" style={{ color: accent }}>
+                      <CountUp target={value ?? 0} />
+                    </p>
                     <p className="text-xs text-gray-500">{label}</p>
                   </div>
-                </div>
+                </motion.div>
               ))}
             </div>
           </section>
 
-          {/* Stats de reportes */}
+          {/* ── Reportes ── */}
           <section className="space-y-3">
-            <div className="flex items-center gap-2.5">
-              <span className="block w-1 h-5 rounded-full bg-blue-400" />
-              <h2 className="text-xs font-bold text-gray-300 uppercase tracking-widest">Reportes</h2>
+            <div className="flex items-center gap-3">
+              <div className="w-6 h-6 rounded-md bg-blue-500/10 border border-blue-500/20 flex items-center justify-center shrink-0">
+                <FileText size={13} className="text-blue-400" />
+              </div>
+              <h2 className="text-sm font-semibold text-gray-300">Reportes</h2>
+              <div className="flex-1 h-px bg-gray-800" />
             </div>
+
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
               {[
-                { label: 'Total',          value: stats.reportes?.total_reportes,    icon: FileText,     color: 'text-gray-200',   accent: '#6B7280', ibg: 'bg-gray-500/10' },
-                { label: 'Este mes',       value: stats.reportes?.reportes_este_mes, icon: TrendingUp,   color: 'text-sky-400',    accent: '#38BDF8', ibg: 'bg-sky-500/10' },
-                { label: 'En seguimiento', value: stats.reportes?.con_seguimiento,   icon: Clock,        color: 'text-yellow-400', accent: '#EAB308', ibg: 'bg-yellow-500/10' },
-                { label: 'Resueltos',      value: stats.reportes?.resueltos,         icon: CheckCircle2, color: 'text-green-400',  accent: '#22C55E', ibg: 'bg-green-500/10' },
-              ].map(({ label, value, icon: Icon, color, accent, ibg }, i) => (
+                { label: 'Total',          value: stats.reportes?.total_reportes,    icon: FileText,     accent: '#9CA3AF', ibg: 'bg-gray-500/10',   border: 'border-gray-600/30' },
+                { label: 'Este mes',       value: stats.reportes?.reportes_este_mes, icon: Activity,     accent: '#38BDF8', ibg: 'bg-sky-500/10',    border: 'border-sky-500/20' },
+                { label: 'En seguimiento', value: stats.reportes?.con_seguimiento,   icon: Clock,        accent: '#EAB308', ibg: 'bg-yellow-500/10', border: 'border-yellow-500/20' },
+                { label: 'Resueltos',      value: stats.reportes?.resueltos,         icon: CheckCircle2, accent: '#22C55E', ibg: 'bg-green-500/10',  border: 'border-green-500/20' },
+              ].map(({ label, value, icon: Icon, accent, ibg, border }, i) => (
                 <motion.div
                   key={label}
-                  initial={{ opacity: 0, y: 10 }}
+                  initial={{ opacity: 0, y: 12 }}
                   animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: i * 0.06 + 0.2 }}
-                  className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden"
-                  style={{ borderTop: `2px solid ${accent}` }}
+                  transition={{ delay: 0.5 + i * 0.07 }}
+                  className="relative bg-gray-900 border border-gray-800 rounded-xl overflow-hidden group hover:border-gray-700 transition-colors"
                 >
-                  <div className="p-4 flex flex-col gap-3">
-                    <div className={`w-8 h-8 rounded-lg ${ibg} flex items-center justify-center`}>
-                      <Icon size={15} className={color} />
+                  <div
+                    className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none"
+                    style={{ background: `radial-gradient(ellipse at top right, ${accent}10 0%, transparent 65%)` }}
+                  />
+                  <div className="relative p-4 flex flex-col gap-3">
+                    <div className={`w-9 h-9 rounded-lg ${ibg} border ${border} flex items-center justify-center`}>
+                      <Icon size={16} style={{ color: accent }} />
                     </div>
                     <div>
-                      <p className={`text-2xl font-bold ${color}`}><CountUp target={value ?? 0} /></p>
+                      <p className="text-2xl font-bold" style={{ color: accent }}>
+                        <CountUp target={value ?? 0} />
+                      </p>
                       <p className="text-xs text-gray-500 mt-0.5">{label}</p>
                     </div>
                   </div>
@@ -138,22 +173,27 @@ export default function AdminPanel() {
             </div>
           </section>
 
-          {/* Accesos rápidos */}
+          {/* ── Acciones rápidas ── */}
           <section className="space-y-3">
-            <div className="flex items-center gap-2.5">
-              <span className="block w-1 h-5 rounded-full bg-purple-400" />
-              <h2 className="text-xs font-bold text-gray-300 uppercase tracking-widest">Acciones rápidas</h2>
+            <div className="flex items-center gap-3">
+              <div className="w-6 h-6 rounded-md bg-purple-500/10 border border-purple-500/20 flex items-center justify-center shrink-0">
+                <TrendingUp size={13} className="text-purple-400" />
+              </div>
+              <h2 className="text-sm font-semibold text-gray-300">Acciones rápidas</h2>
+              <div className="flex-1 h-px bg-gray-800" />
             </div>
+
             <div className="grid sm:grid-cols-2 gap-4">
               <Link
                 to="/admin/usuarios"
-                className="group bg-gray-900 border border-gray-800 hover:border-yellow-500/50 rounded-xl p-5 flex items-center gap-4 transition-all duration-300 hover:bg-yellow-500/5"
+                className="group relative bg-gray-900 border border-gray-800 hover:border-yellow-500/40 rounded-xl p-5 flex items-center gap-4 transition-all duration-300 overflow-hidden"
               >
-                <div className="w-12 h-12 rounded-xl bg-yellow-500/10 border border-yellow-500/20 flex items-center justify-center shrink-0 group-hover:bg-yellow-500/20 transition-colors">
-                  <Users size={22} className="text-yellow-400" />
+                <div className="absolute inset-0 bg-gradient-to-br from-yellow-500/0 to-yellow-500/0 group-hover:from-yellow-500/5 group-hover:to-transparent transition-all duration-300 pointer-events-none" />
+                <div className="w-12 h-12 rounded-xl bg-yellow-500/10 border border-yellow-500/20 flex items-center justify-center shrink-0 group-hover:bg-yellow-500/20 group-hover:border-yellow-500/40 transition-all duration-300">
+                  <Users size={20} className="text-yellow-400" />
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-semibold text-gray-100">Gestión de usuarios</p>
+                  <p className="text-sm font-semibold text-gray-100 group-hover:text-yellow-100 transition-colors">Gestión de usuarios</p>
                   <p className="text-xs text-gray-500 mt-0.5">Cambiar roles, activar/desactivar cuentas</p>
                 </div>
                 <ArrowRight size={16} className="text-gray-600 group-hover:text-yellow-400 group-hover:translate-x-1 transition-all shrink-0" />
@@ -161,13 +201,14 @@ export default function AdminPanel() {
 
               <Link
                 to="/moderacion"
-                className="group bg-gray-900 border border-gray-800 hover:border-blue-500/50 rounded-xl p-5 flex items-center gap-4 transition-all duration-300 hover:bg-blue-500/5"
+                className="group relative bg-gray-900 border border-gray-800 hover:border-blue-500/40 rounded-xl p-5 flex items-center gap-4 transition-all duration-300 overflow-hidden"
               >
-                <div className="w-12 h-12 rounded-xl bg-blue-500/10 border border-blue-500/20 flex items-center justify-center shrink-0 group-hover:bg-blue-500/20 transition-colors">
-                  <ShieldCheck size={22} className="text-blue-400" />
+                <div className="absolute inset-0 bg-gradient-to-br from-blue-500/0 to-blue-500/0 group-hover:from-blue-500/5 group-hover:to-transparent transition-all duration-300 pointer-events-none" />
+                <div className="w-12 h-12 rounded-xl bg-blue-500/10 border border-blue-500/20 flex items-center justify-center shrink-0 group-hover:bg-blue-500/20 group-hover:border-blue-500/40 transition-all duration-300">
+                  <ShieldCheck size={20} className="text-blue-400" />
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-semibold text-gray-100">Moderación de reportes</p>
+                  <p className="text-sm font-semibold text-gray-100 group-hover:text-blue-100 transition-colors">Moderación de reportes</p>
                   <p className="text-xs text-gray-500 mt-0.5">Revisar y gestionar el estado de reportes</p>
                 </div>
                 <ArrowRight size={16} className="text-gray-600 group-hover:text-blue-400 group-hover:translate-x-1 transition-all shrink-0" />


### PR DESCRIPTION
## Descripción

Reemplaza el diseño genérico con tarjetas de borde superior coloreado por uno moderno: acento yellow-400 en el título, pill de estado animado, tarjetas con radial-gradient en hover, iconos UserCheck/UserX/UserPlus en la fila secundaria y divisores horizontales en títulos de sección. Limpieza de imports no usados.

### Archivos afectados:
- src/pages/AdminPanel.jsx - header con icono+yellow-400, pill 'Sistema en línea', radial-gradient en tarjetas, fila secundaria con iconos, títulos de sección con divisor horizontal, imports limpios

Closes #91

<img width="917" height="641" alt="image" src="https://github.com/user-attachments/assets/57d4dee8-2fe4-47c9-bc05-f5c23e1b9ec1" />
