### PR TITLE
fix(navbar): mostrar avatar del usuario en el menu de navegacion (#102)

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -144,8 +144,11 @@ export default function Navbar() {
                   onClick={() => setUserMenuOpen((v) => !v)}
                   className="flex items-center gap-2 pl-3 pr-2 py-1.5 rounded-lg border border-gray-700 bg-gray-900 hover:border-gray-600 transition"
                 >
-                  <span className="w-6 h-6 rounded-full bg-green-500/20 border border-green-500/40 flex items-center justify-center text-green-400 text-xs font-bold">
-                    {user.nombre?.charAt(0).toUpperCase()}
+                  <span className="w-6 h-6 rounded-full bg-green-500/20 border border-green-500/40 flex items-center justify-center text-green-400 text-xs font-bold overflow-hidden shrink-0">
+                    {user.avatar_url
+                      ? <img src={user.avatar_url} alt={user.nombre} className="w-full h-full object-cover" />
+                      : user.nombre?.charAt(0).toUpperCase()
+                    }
                   </span>
                   <div className="text-left leading-tight hidden lg:block">
                     <p className="text-xs font-medium text-gray-200 max-w-[110px] truncate">{`${user.nombre}`.trim()}</p>
@@ -269,8 +272,11 @@ export default function Navbar() {
             <>
               {/* Info usuario en mobile */}
               <div className="flex items-center gap-3 px-3 py-3 bg-gray-900 rounded-lg border border-gray-800">
-                <span className="w-9 h-9 rounded-full bg-green-500/20 border border-green-500/40 flex items-center justify-center text-green-400 font-bold shrink-0">
-                  {user.nombre?.charAt(0).toUpperCase()}
+                <span className="w-9 h-9 rounded-full bg-green-500/20 border border-green-500/40 flex items-center justify-center text-green-400 font-bold shrink-0 overflow-hidden">
+                  {user.avatar_url
+                    ? <img src={user.avatar_url} alt={user.nombre} className="w-full h-full object-cover" />
+                    : user.nombre?.charAt(0).toUpperCase()
+                  }
                 </span>
                 <div className="min-w-0">
                   <p className="text-sm font-medium text-gray-200 truncate">{user.nombre}</p>


### PR DESCRIPTION
## Descripción:

El avatar en desktop y mobile mostraba solo la inicial del nombre. Ahora si el usuario tiene avatar_url configurado se muestra la imagen con object-cover. Si no hay imagen se mantiene la inicial como fallback. Se añade overflow-hidden y shrink-0 al span contenedor.

### Archivos afectados:
- src/components/Navbar.jsx - avatar desktop (~L147) con condicional avatar_url, avatar mobile (~L275) con mismo patron

Closes #102
---
<img width="506" height="72" alt="image" src="https://github.com/user-attachments/assets/7d965f6a-d14f-45f1-8479-272b73ad7d5e" />

