### PR TITLE
fix(reports): corregir limite de destacados de 3 a 5 por seccion

### DIFF
--- a/src/pages/Reports.jsx
+++ b/src/pages/Reports.jsx
@@ -268,11 +268,11 @@ export default function Reports() {
   const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
   const paginated  = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
-  // ── Trending interno: top-3 por likes y top-3 por vistas ────────────────
+  // ── Trending interno: top-5 por likes y top-5 por vistas ────────────────
   const trending = useMemo(() => {
     if (reports.length < 2) return null;
-    const byLikes  = [...reports].sort((a, b) => Number(b.votos_relevancia) - Number(a.votos_relevancia)).slice(0, 3);
-    const byVistas = [...reports].sort((a, b) => Number(b.vistas) - Number(a.vistas)).slice(0, 3);
+    const byLikes  = [...reports].sort((a, b) => Number(b.votos_relevancia) - Number(a.votos_relevancia)).slice(0, 5);
+    const byVistas = [...reports].sort((a, b) => Number(b.vistas) - Number(a.vistas)).slice(0, 5);
     if (!byLikes[0]?.votos_relevancia && !byVistas[0]?.vistas) return null;
     return { likes: byLikes, vistas: byVistas };
   }, [reports]);
@@ -465,7 +465,7 @@ export default function Reports() {
         )}
       </AnimatePresence>
 
-      {/* ── TRENDING — Top 3 por likes y vistas, estilo Netflix ── */}
+      {/* ── TRENDING — Top 5 por likes y vistas, estilo Netflix ── */}
       {!loading && trending && (
         <motion.section
           className="space-y-4"


### PR DESCRIPTION
## Descripción:
La sección de tendencias en /reports mostraba únicamente 3 tarjetas por columna (más populares y más vistos) debido a un .slice(0, 3) codificado en el useMemo de trending. El requerimiento especifica 5 destacados por sección.

## Proceso de resolución:
- Bug detectado: la UI mostraba solo 3 tarjetas por seccion trending
- Causa raiz: .slice(0, 3) en ambas ordenaciones del useMemo trending
- Solucion: cambiar .slice(0, 3) por .slice(0, 5) en byLikes y byVistas
- Verificacion: orden de secciones confirmado (populares -> vistos)

### Archivos afectados:
- src/pages/Reports.jsx: lineas 274-275, useMemo trending