### PR TITLE
Rename CI Frontend workflow to CI/CD Frontend

### DIFF
--- a/.github/workflows/CiFrontend.yml
+++ b/.github/workflows/CiFrontend.yml
@@ -1,4 +1,4 @@
-name: CI Frontend
+name: CI/CD Frontend
 
 on:
   push:
@@ -62,6 +62,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
## Descripción.
Se ajusta el archivo YML del workflow de github par el deploy del frontend.

### Archivos afectados:
- Cifrontend.yml

---

<img width="586" height="144" alt="{459256CD-9369-43C5-8104-15E4C1FA38F9}" src="https://github.com/user-attachments/assets/9dd3c494-8723-455e-b8cb-67549dfd042a" />
