### PR TITLE
Feat/docker compose prod hardening

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,4 +13,3 @@ build
 *.md
 Dockerfile
 docker-compose.yml
-nginx

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+npm-debug.log
+dist
+build
+.env
+.env.local
+.env.*.local
+.git
+.github
+.gitignore
+.vscode
+.idea
+*.md
+Dockerfile
+docker-compose.yml
+nginx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 # ── Stage 1: Base (Entorno Común) ──────────────────────────────────────────
 FROM node:20-alpine AS base
 
+LABEL org.opencontainers.image.title="Green Alert Frontend" \
+      org.opencontainers.image.description="SPA React + Vite para Green Alert" \
+      org.opencontainers.image.source="https://github.com/green-alert" \
+      org.opencontainers.image.licenses="MIT"
+
 # Definir directorio de trabajo principal
 WORKDIR /app
 
@@ -88,6 +93,10 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 
 # Exponer el puerto 8080
 EXPOSE 8080
+
+# Health check: verifica que nginx sirve el index.html correctamente
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -q --spider http://localhost:8080/ || exit 1
 
 # Comando para arrancar Nginx en primer plano
 CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,93 @@
-# ── Stage 1: Build ──────────────────────────────────────────────────────────
-FROM node:20-alpine AS builder
+# ── Stage 1: Base (Entorno Común) ──────────────────────────────────────────
+FROM node:20-alpine AS base
 
+# Definir directorio de trabajo principal
 WORKDIR /app
 
-# Copiar manifests antes del código fuente para aprovechar caché de capas
+# Copiar archivos de dependencias
 COPY package.json package-lock.json .npmrc ./
-RUN npm ci --legacy-peer-deps
 
-# Copiar el resto del código fuente y generar el bundle de producción
+
+# ── Stage 2: Desarrollo (Para docker-compose de desarrollo) ───────────────
+FROM base AS development
+
+# Instalar todas las dependencias (incluyendo devDependencies para compilar)
+RUN npm install
+
+# Copiar el código fuente completo del Frontend
 COPY . .
+
+# Exponer el puerto por defecto de Vite (5173)
+EXPOSE 5173
+
+# Arrancar el servidor de desarrollo escuchando en 0.0.0.0 para acceso externo
+CMD ["npm", "run", "dev", "--", "--host"]
+
+
+# ── Stage 3: Builder (Generación del Bundle de Producción) ─────────────────
+FROM base AS builder
+
+# Instalar dependencias usando npm ci para asegurar consistencia e inmutabilidad
+RUN npm ci
+
+# ── DEFINICIÓN DE ARGUMENTOS DE CONSTRUCCIÓN (Vite Build-time Env Vars) ───
+# React/Vite inyectan las variables VITE_* de manera estática durante el build.
+# Declaramos los argumentos para que puedan ser pasados en el docker-compose o comando build.
+ARG VITE_API_URL
+ARG VITE_APP_NAME
+ARG VITE_APP_VERSION
+ARG VITE_ENV=production
+ARG VITE_ENABLE_MAPS
+ARG VITE_ENABLE_NOTIFICATIONS
+ARG VITE_ENABLE_IA_FEATURES
+ARG VITE_MAPBOX_TOKEN
+ARG VITE_GOOGLE_MAPS_KEY
+ARG VITE_FIREBASE_API_KEY
+ARG VITE_FIREBASE_AUTH_DOMAIN
+ARG VITE_FIREBASE_PROJECT_ID
+ARG VITE_FIREBASE_STORAGE_BUCKET
+ARG VITE_FIREBASE_MESSAGING_SENDER_ID
+ARG VITE_FIREBASE_APP_ID
+ARG VITE_FIREBASE_VAPID_KEY
+
+# Mapear los argumentos a variables de entorno para que Vite los detecte en el build
+ENV VITE_API_URL=$VITE_API_URL \
+    VITE_APP_NAME=$VITE_APP_NAME \
+    VITE_APP_VERSION=$VITE_APP_VERSION \
+    VITE_ENV=$VITE_ENV \
+    VITE_ENABLE_MAPS=$VITE_ENABLE_MAPS \
+    VITE_ENABLE_NOTIFICATIONS=$VITE_ENABLE_NOTIFICATIONS \
+    VITE_ENABLE_IA_FEATURES=$VITE_ENABLE_IA_FEATURES \
+    VITE_MAPBOX_TOKEN=$VITE_MAPBOX_TOKEN \
+    VITE_GOOGLE_MAPS_KEY=$VITE_GOOGLE_MAPS_KEY \
+    VITE_FIREBASE_API_KEY=$VITE_FIREBASE_API_KEY \
+    VITE_FIREBASE_AUTH_DOMAIN=$VITE_FIREBASE_AUTH_DOMAIN \
+    VITE_FIREBASE_PROJECT_ID=$VITE_FIREBASE_PROJECT_ID \
+    VITE_FIREBASE_STORAGE_BUCKET=$VITE_FIREBASE_STORAGE_BUCKET \
+    VITE_FIREBASE_MESSAGING_SENDER_ID=$VITE_FIREBASE_MESSAGING_SENDER_ID \
+    VITE_FIREBASE_APP_ID=$VITE_FIREBASE_APP_ID \
+    VITE_FIREBASE_VAPID_KEY=$VITE_FIREBASE_VAPID_KEY
+
+# Copiar el código fuente
+COPY . .
+
+# Compilar los archivos estáticos listos para producción (se generarán en /app/dist)
 RUN npm run build
 
-# ── Stage 2: Servir con nginx ────────────────────────────────────────────────
-FROM nginx:1.27-alpine AS runner
 
-# Configuración nginx optimizada para SPA con HTML5 History API
-RUN printf '%s\n' \
-  'server {' \
-  '    listen 80;' \
-  '    server_name _;' \
-  '    root /usr/share/nginx/html;' \
-  '    index index.html;' \
-  '' \
-  '    gzip on;' \
-  '    gzip_vary on;' \
-  '    gzip_types text/plain text/css application/json application/javascript' \
-  '               text/xml application/xml image/svg+xml;' \
-  '' \
-  '    # Assets con hash de contenido: caché inmutable de 1 año' \
-  '    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {' \
-  '        expires 1y;' \
-  '        add_header Cache-Control "public, immutable";' \
-  '    }' \
-  '' \
-  '    # SPA fallback: cualquier ruta sirve index.html' \
-  '    location / {' \
-  '        try_files $uri $uri/ /index.html;' \
-  '    }' \
-  '}' > /etc/nginx/conf.d/default.conf
+# ── Stage 4: Producción Ejecutable (Nginx sin privilegios de root) ────────
+# Usamos nginx-unprivileged para cumplir con el estándar de mínima autorización (Non-Root User).
+# Por defecto escucha en el puerto 8080.
+FROM nginxinc/nginx-unprivileged:1.27-alpine AS production
 
+# Copiar la configuración optimizada y segura de Nginx
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+
+# Copiar los assets estáticos generados en la fase de builder
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-EXPOSE 80
+# Exponer el puerto 8080
+EXPOSE 8080
 
+# Comando para arrancar Nginx en primer plano
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,82 @@
+version: '3.8'
+
+services:
+  # ── SERVICIO DE DESARROLLO (Vite Dev Server con Node 20) ────────────────
+  frontend-dev:
+    container_name: green-alert-frontend-dev
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
+    image: green-alert-frontend:dev
+    ports:
+      - "5173:5173"
+    environment:
+      - NODE_ENV=development
+      - VITE_ENV=development
+    env_file:
+      - .env
+    volumes:
+      # Sincronizar directorios de código fuente para habilitar Hot Module Replacement (HMR)
+      - ./src:/app/src:ro
+      - ./public:/app/public:ro
+      - ./index.html:/app/index.html:ro
+      - ./vite.config.js:/app/vite.config.js:ro
+      - ./tailwind.config.js:/app/tailwind.config.js:ro
+      - ./postcss.config.js:/app/postcss.config.js:ro
+      # Evitar que node_modules local sobrescriba el del contenedor (muy crítico para Windows/WSL/Mac)
+      - /app/node_modules
+    restart: unless-stopped
+    stdin_open: true
+    tty: true
+    networks:
+      - green-alert-net
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  # ── SERVICIO DE PRODUCCIÓN (Nginx Seguro sin root) ──────────────────────
+  frontend-prod:
+    container_name: green-alert-frontend-prod
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: production
+      # Argumentos de construcción pasados desde el archivo .env o variables del host
+      # Requerido porque Vite inyecta las variables estáticamente en el bundle de JS
+      args:
+        VITE_API_URL: ${VITE_API_URL:-http://localhost:3000}
+        VITE_APP_NAME: ${VITE_APP_NAME:-GreenAlert}
+        VITE_APP_VERSION: ${VITE_APP_VERSION:-2.0.0}
+        VITE_ENV: ${VITE_ENV:-production}
+        VITE_ENABLE_MAPS: ${VITE_ENABLE_MAPS:-true}
+        VITE_ENABLE_NOTIFICATIONS: ${VITE_ENABLE_NOTIFICATIONS:-true}
+        VITE_ENABLE_IA_FEATURES: ${VITE_ENABLE_IA_FEATURES:-false}
+        VITE_MAPBOX_TOKEN: ${VITE_MAPBOX_TOKEN:-your_mapbox_token_here}
+        VITE_GOOGLE_MAPS_KEY: ${VITE_GOOGLE_MAPS_KEY:-your_google_maps_key_here}
+        VITE_FIREBASE_API_KEY: ${VITE_FIREBASE_API_KEY:-AIzaSyBMMamcR8KTSMc60LQvsXdyUAvnbN0xspY}
+        VITE_FIREBASE_AUTH_DOMAIN: ${VITE_FIREBASE_AUTH_DOMAIN:-green-alert-1.firebaseapp.com}
+        VITE_FIREBASE_PROJECT_ID: ${VITE_FIREBASE_PROJECT_ID:-green-alert-1}
+        VITE_FIREBASE_STORAGE_BUCKET: ${VITE_FIREBASE_STORAGE_BUCKET:-green-alert-1.firebasestorage.app}
+        VITE_FIREBASE_MESSAGING_SENDER_ID: ${VITE_FIREBASE_MESSAGING_SENDER_ID:-141245905908}
+        VITE_FIREBASE_APP_ID: ${VITE_FIREBASE_APP_ID:-1:141245905908:web:8074ab75778af7c94f97a1}
+        VITE_FIREBASE_VAPID_KEY: ${VITE_FIREBASE_VAPID_KEY:-BD3e67M0AI8IpfsXsMq3K-6LSQb3aiLRPR9vARMbqZ2Y0-RhbEbqQg4NOOyYtnCpmabUAuuH3vPhXKCsQtGeXsI}
+    image: green-alert-frontend:latest
+    ports:
+      # Nginx-unprivileged corre internamente en el 8080.
+      # Lo mapeamos al puerto 80 estándar del host de producción (o 8080 si se prefiere).
+      - "80:8080"
+    restart: unless-stopped
+    networks:
+      - green-alert-net
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+networks:
+  green-alert-net:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,82 +1,51 @@
-version: '3.8'
+name: green-alert-frontend
+
+# ╔══════════════════════════════════════════════════════════════════════════╗
+# ║  Docker Compose STANDALONE – Frontend (Producción)                      ║
+# ║                                                                          ║
+# ║  Uso:                                                                    ║
+# ║    1. Copia .env.example → .env y rellena los valores reales             ║
+# ║    2. docker compose up --build -d                                       ║
+# ║                                                                          ║
+# ║  Las variables VITE_* se hornean (bake) en el bundle estático durante    ║
+# ║  el build. No se inyectan en tiempo de ejecución; por eso se pasan como  ║
+# ║  build args y NO como env_file del contenedor en ejecución.              ║
+# ╚══════════════════════════════════════════════════════════════════════════╝
 
 services:
-  # ── SERVICIO DE DESARROLLO (Vite Dev Server con Node 20) ────────────────
-  frontend-dev:
-    container_name: green-alert-frontend-dev
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: development
-    image: green-alert-frontend:dev
-    ports:
-      - "5173:5173"
-    environment:
-      - NODE_ENV=development
-      - VITE_ENV=development
-    env_file:
-      - .env
-    volumes:
-      # Sincronizar directorios de código fuente para habilitar Hot Module Replacement (HMR)
-      - ./src:/app/src:ro
-      - ./public:/app/public:ro
-      - ./index.html:/app/index.html:ro
-      - ./vite.config.js:/app/vite.config.js:ro
-      - ./tailwind.config.js:/app/tailwind.config.js:ro
-      - ./postcss.config.js:/app/postcss.config.js:ro
-      # Evitar que node_modules local sobrescriba el del contenedor (muy crítico para Windows/WSL/Mac)
-      - /app/node_modules
-    restart: unless-stopped
-    stdin_open: true
-    tty: true
-    networks:
-      - green-alert-net
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
-
-  # ── SERVICIO DE PRODUCCIÓN (Nginx Seguro sin root) ──────────────────────
-  frontend-prod:
-    container_name: green-alert-frontend-prod
+  frontend:
+    container_name: green-alert-frontend
     build:
       context: .
       dockerfile: Dockerfile
       target: production
-      # Argumentos de construcción pasados desde el archivo .env o variables del host
-      # Requerido porque Vite inyecta las variables estáticamente en el bundle de JS
+      # Las variables VITE_* son leídas por Docker Compose desde el .env
+      # del directorio actual y pasadas al build de Vite como ARGs.
       args:
-        VITE_API_URL: ${VITE_API_URL:-http://localhost:3000}
-        VITE_APP_NAME: ${VITE_APP_NAME:-GreenAlert}
-        VITE_APP_VERSION: ${VITE_APP_VERSION:-2.0.0}
-        VITE_ENV: ${VITE_ENV:-production}
-        VITE_ENABLE_MAPS: ${VITE_ENABLE_MAPS:-true}
-        VITE_ENABLE_NOTIFICATIONS: ${VITE_ENABLE_NOTIFICATIONS:-true}
-        VITE_ENABLE_IA_FEATURES: ${VITE_ENABLE_IA_FEATURES:-false}
-        VITE_MAPBOX_TOKEN: ${VITE_MAPBOX_TOKEN:-your_mapbox_token_here}
-        VITE_GOOGLE_MAPS_KEY: ${VITE_GOOGLE_MAPS_KEY:-your_google_maps_key_here}
-        VITE_FIREBASE_API_KEY: ${VITE_FIREBASE_API_KEY:-AIzaSyBMMamcR8KTSMc60LQvsXdyUAvnbN0xspY}
-        VITE_FIREBASE_AUTH_DOMAIN: ${VITE_FIREBASE_AUTH_DOMAIN:-green-alert-1.firebaseapp.com}
-        VITE_FIREBASE_PROJECT_ID: ${VITE_FIREBASE_PROJECT_ID:-green-alert-1}
-        VITE_FIREBASE_STORAGE_BUCKET: ${VITE_FIREBASE_STORAGE_BUCKET:-green-alert-1.firebasestorage.app}
-        VITE_FIREBASE_MESSAGING_SENDER_ID: ${VITE_FIREBASE_MESSAGING_SENDER_ID:-141245905908}
-        VITE_FIREBASE_APP_ID: ${VITE_FIREBASE_APP_ID:-1:141245905908:web:8074ab75778af7c94f97a1}
-        VITE_FIREBASE_VAPID_KEY: ${VITE_FIREBASE_VAPID_KEY:-BD3e67M0AI8IpfsXsMq3K-6LSQb3aiLRPR9vARMbqZ2Y0-RhbEbqQg4NOOyYtnCpmabUAuuH3vPhXKCsQtGeXsI}
+        VITE_API_URL:                    ${VITE_API_URL}
+        VITE_APP_NAME:                   ${VITE_APP_NAME:-GreenAlert}
+        VITE_APP_VERSION:                ${VITE_APP_VERSION:-2.0.0}
+        VITE_ENV:                        ${VITE_ENV:-production}
+        VITE_ENABLE_MAPS:                ${VITE_ENABLE_MAPS:-true}
+        VITE_ENABLE_NOTIFICATIONS:       ${VITE_ENABLE_NOTIFICATIONS:-true}
+        VITE_ENABLE_IA_FEATURES:         ${VITE_ENABLE_IA_FEATURES:-false}
+        VITE_MAPBOX_TOKEN:               ${VITE_MAPBOX_TOKEN:-}
+        VITE_GOOGLE_MAPS_KEY:            ${VITE_GOOGLE_MAPS_KEY:-}
+        VITE_FIREBASE_API_KEY:           ${VITE_FIREBASE_API_KEY}
+        VITE_FIREBASE_AUTH_DOMAIN:       ${VITE_FIREBASE_AUTH_DOMAIN}
+        VITE_FIREBASE_PROJECT_ID:        ${VITE_FIREBASE_PROJECT_ID}
+        VITE_FIREBASE_STORAGE_BUCKET:    ${VITE_FIREBASE_STORAGE_BUCKET}
+        VITE_FIREBASE_MESSAGING_SENDER_ID: ${VITE_FIREBASE_MESSAGING_SENDER_ID}
+        VITE_FIREBASE_APP_ID:            ${VITE_FIREBASE_APP_ID}
+        VITE_FIREBASE_VAPID_KEY:         ${VITE_FIREBASE_VAPID_KEY}
     image: green-alert-frontend:latest
-    ports:
-      # Nginx-unprivileged corre internamente en el 8080.
-      # Lo mapeamos al puerto 80 estándar del host de producción (o 8080 si se prefiere).
-      - "80:8080"
     restart: unless-stopped
-    networks:
-      - green-alert-net
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
-
-networks:
-  green-alert-net:
-    driver: bridge
+    ports:
+      # nginx-unprivileged escucha en 8080 → se publica en el puerto 80 del host
+      - "80:8080"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/"]
+      interval: 15s
+      timeout: 5s
+      start_period: 10s
+      retries: 5

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,65 @@
+server {
+    listen 8080;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # ── Habilitar Compresión Gzip ───────────────────────────────────────────
+    gzip on;
+    gzip_disable "msie6";
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types
+        text/plain
+        text/css
+        application/json
+        application/javascript
+        text/xml
+        application/xml
+        application/xml+rss
+        text/javascript
+        image/svg+xml;
+
+    # ── Cabeceras de Seguridad Avanzadas (Buenas Prácticas OWASP) ────────────
+    # Evita clickjacking al no permitir renderizar la app en iframes
+    add_header X-Frame-Options "DENY" always;
+    
+    # Evita vulnerabilidades de MIME-type sniffing
+    add_header X-Content-Type-Options "nosniff" always;
+    
+    # Activa la protección XSS en navegadores antiguos
+    add_header X-XSS-Protection "1; mode=block" always;
+    
+    # Limita la información del referente al navegar fuera de la aplicación
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    
+    # Política de permisos para restringir acceso a APIs de hardware del navegador
+    add_header Permissions-Policy "geolocation=(self), camera=(), microphone=(), payment=()" always;
+
+    # Content Security Policy (CSP): Protege contra ataques XSS e inyecciones de datos
+    # NOTA: Ajustado para permitir funcionamiento de fuentes de Google, Firebase y Leaflet Maps.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://apis.google.com https://www.gstatic.com; connect-src 'self' http://localhost:3000 wss: https:; img-src 'self' data: blob: https: *.tile.openstreetmap.org; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; frame-src 'self' https://*.firebaseapp.com;" always;
+
+    # ── Caché Inmutable para Assets Estáticos ──────────────────────────────
+    # Las tecnologías modernas como Vite generan nombres de archivo únicos (hashes de contenido).
+    # Por tanto, podemos cachearlos indefinidamente sin riesgo de servir código obsoleto.
+    location ~* \.(?:js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, no-transform, immutable";
+        access_log off;
+    }
+
+    # ── SPA Fallback (Soporte para React Router / HTML5 History API) ────────
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Redirección de errores estándar a la página index.html de la SPA
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+        root /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
## Descripción
Se simplifica la configuracion Docker del frontend eliminando el servicio de desarrollo del docker-compose y consolidando todo en un unico servicio de produccion. Se afiaden mejoras de seguridad y observabilidad.

### Cambios realizados:
- Elimina el servicio frontend-dev del docker-compose (Vite dev server)
- Renombra frontend-prod -> frontend para mayor claridad
- Afinade campo 'name: green-alert-frontend' al compose (Compose V2)
- Elimina valores por defecto hardcodeados de secretos Firebase y Mapbox en build args
- Afinade HEALTHCHECK en Dockerfile (wget al index.html cada 30s, 3 reintentos)
- Afinade healthcheck en docker-compose con intervalos ajustados (15s/5s/10s)
- Afinade etiquetas OCI (LABEL) al Dockerfile con metadatos de imagen
- Elimina red personalizada green-alert-net (usa red default de Compose)
- Quita 'nginx' del .dockerignore para incluir la config de nginx en el contexto de build

### Archivos afectados:
- Dockerfile: etiquetas OCI + HEALTHCHECK
- docker-compose.yml: refactor completo a servicio unico de produccion
- .dockerignore: elimina exclusion de directorio nginx

<img width="971" height="82" alt="{570B9499-9293-4254-9E48-93EDC0A76A11}" src="https://github.com/user-attachments/assets/4a6aed91-1813-4b05-99ff-62b81710a381" />
