### PR TITLE
fix(entidad): corregir rutas API del panel de entidad y navegacion por rol.

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -9,7 +9,7 @@ import CampanaNotificaciones from './notificaciones/CampanaNotificaciones.jsx';
 
 const navItems = [
   { to: '/',           label: 'Inicio',          end: true,  guestOnly: true, scrollToTop: true },
-  { to: '/dashboard',  label: 'Página Principal', authOnly: true },
+  { to: '/dashboard',  label: 'Página Principal', roles: ['ciudadano', 'moderador', 'admin'] },
   { to: '/reports',    label: 'Reportes',         authOnly: true },
   { to: '/entidad',    label: 'Mi Entidad',       roles: ['entidad'] },
   { to: '/moderacion', label: 'Moderación',       roles: ['moderador', 'admin'] },

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -169,7 +169,7 @@ export const analizarImagenIA = (file) => {
     timeout: 30000,
   });
 };
-// FE-31 (BE-16): sugerencia de título y descripción basada en imágenes adjuntas
+// sugerencia de título y descripción basada en imágenes adjuntas
 export const sugerirContenidoReporte = (formData) =>
   api.post('/reportes/sugerir-contenido', formData, {
     headers: { 'Content-Type': 'multipart/form-data' },
@@ -177,7 +177,7 @@ export const sugerirContenidoReporte = (formData) =>
   });
 export const updateReporte  = (id, data)   => api.patch(`/reportes/${id}`, data);
 export const deleteReporte  = (id)         => api.delete(`/reportes/${id}`);
-export const exportReportes = (params)     => api.get('/reportes/export', { params });
+export const exportReportes = (params)     => api.get('/reportes/export', { params, responseType: 'arraybuffer' });
 
 // Likes y tendencias
 export const toggleLikeReporte  = (id)         => api.post(`/reportes/${id}/like`);

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -229,10 +229,10 @@ export const getEntidades = () => api.get('/entidades');
 export const asignarReporteEntidad = (idReporte, data) => api.post(`/reportes/${idReporte}/asignaciones`, data);
 
 // ── Panel de entidad ──
-export const getMisReportesEntidad          = (params)           => api.get('/entidad/reportes', { params });
-export const getMiReporteEntidad            = (idReporte)        => api.get(`/entidad/reportes/${idReporte}`);
-export const actualizarAtencionEntidad      = (idReporte, data)  => api.patch(`/entidad/reportes/${idReporte}/atencion`, data);
-export const getMisAlertasEntidad           = (params)           => api.get('/entidad/alertas', { params });
-export const getMisAlertasNoLeidasCountEntidad = ()              => api.get('/entidad/alertas/contador');
-export const marcarAlertaEntidadLeida       = (idAlerta)         => api.patch(`/entidad/alertas/${idAlerta}/leida`);
-export const marcarTodasAlertasEntidadLeidas = ()                => api.patch('/entidad/alertas/marcar-todas');
+export const getMisReportesEntidad             = (params)          => api.get('/entidades/mis-reportes', { params });
+export const getMiReporteEntidad               = (idReporte)       => api.get(`/entidades/mis-reportes/${idReporte}`);
+export const actualizarAtencionEntidad         = (idReporte, data) => api.patch(`/entidades/mis-reportes/${idReporte}/atencion`, data);
+export const getMisAlertasEntidad              = (params)          => api.get('/entidades/mis-alertas', { params });
+export const getMisAlertasNoLeidasCountEntidad = ()                => api.get('/entidades/mis-alertas/no-leidas/count');
+export const marcarAlertaEntidadLeida          = (idAlerta)        => api.patch(`/entidades/mis-alertas/${idAlerta}/leer`);
+export const marcarTodasAlertasEntidadLeidas   = ()                => api.patch('/entidades/mis-alertas/leer-todas');


### PR DESCRIPTION
## Descripción:

Las URLs del panel de entidad apuntaban a prefijos incorrectos (/entidad/*) que no existian en el backend. El router esta montado en /entidades (plural) con subrutas /mis-reportes y /mis-alertas, causando error 404 en todas las peticiones del panel de entidad (reportes asignados, alertas, actualizacion de atencion). Adicionalmente, el item 'Pagina Principal' del navbar aparecia para todos los roles incluyendo entidad, que debe ir directamente a /entidad.

### Archivos afectados:
  src/services/api.js
    - getMisReportesEntidad:          /entidad/reportes        -> /entidades/mis-reportes
    - getMiReporteEntidad:            /entidad/reportes/:id    -> /entidades/mis-reportes/:id
    - actualizarAtencionEntidad:      /entidad/reportes/:id/atencion -> /entidades/mis-reportes/:id/atencion
    - getMisAlertasEntidad:           /entidad/alertas         -> /entidades/mis-alertas
    - getMisAlertasNoLeidasCountEntidad: /entidad/alertas/contador -> /entidades/mis-alertas/no-leidas/count
    - marcarAlertaEntidadLeida:       /entidad/alertas/:id/leida -> /entidades/mis-alertas/:id/leer
    - marcarTodasAlertasEntidadLeidas: /entidad/alertas/marcar-todas -> /entidades/mis-alertas/leer-todas

 ° src/components/Navbar.jsx
    - 'Pagina Principal' pasa de authOnly (todos los auth) a roles especificos [ciudadano, moderador, admin], excluyendo entidad

## Conclusion:
  El panel de entidad ahora puede cargar reportes asignados, alertas y actualizar el estado de atención correctamente. Los usuarios con rol entidad ven únicamente 'Reportes' y 'Mi Entidad' en la navegación, sin el enlace a Dashboard que no les corresponde.

<img width="1292" height="507" alt="{A814B3BC-0B81-4A4E-848C-B70B9BB54BE1}" src="https://github.com/user-attachments/assets/9c90d8fd-0359-48e3-952c-548fb4387fcb" />
